### PR TITLE
Fixes duplicate channel events in cluster

### DIFF
--- a/apps/slacker_frontend/assets/application.vue
+++ b/apps/slacker_frontend/assets/application.vue
@@ -67,9 +67,14 @@ export default {
 
       socket.connect();
       channel.join();
-
       channel.on("sync", ({ channels }) => this.channels = channels);
-      channel.on("new-channel", ({ name }) => this.channels.push(name));
+
+      channel.on("new-channel", ({ name }) => {
+        if (!this.channels.includes(name)) {
+          this.channels.push(name);
+        }
+      });
+
       channel.on("delete-channel", ({ name }) => {
         const idx = this.channels.findIndex((channel) => name === channel);
 


### PR DESCRIPTION
Notes: 
- `SlackerBackend.Leader.Registry` is now responsible for broadcasting channel events _only_ locally
- Add client logic to eliminate duplicate channels